### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The MangoHacks CLI 🍐
     -h, --help        Show help message and close
     -v, --version     View package version
 
-  Feedback falgs:
+  Feedback flags:
     -m, --message     Set a feedback message
     -s, --subject     Set a feedback subject
 

--- a/cli.js
+++ b/cli.js
@@ -32,7 +32,7 @@ const cli = meow(`
 	  -h, --help        Show help message and close
 	  -v, --version     View package version
 
-	Feedback falgs:
+	Feedback flags:
 	  -m, --message     Set a feedback message
 	  -s, --subject     Set a feedback subject
 


### PR DESCRIPTION
Replace `falgs` by `flags` on `README.md` and `cli.js`.

It closes #1 